### PR TITLE
Add HTTP OPTIONS request handler to routing framework

### DIFF
--- a/Routing/Router.class.php
+++ b/Routing/Router.class.php
@@ -578,8 +578,8 @@ class Router
                 return 'DELETE';
             // case 'HEAD':
             //     return 'HEAD';
-            // case 'OPTIONS':
-            //     return 'OPTIONS';
+            case 'OPTIONS':
+                return 'OPTIONS';
             default:
                 return 'GET';
         }
@@ -672,6 +672,18 @@ class Router
     {
         $type = $this->getType();
         $uri  = getenv('REQUEST_URI');
+        if ($type == 'OPTIONS') {
+            $url_parts = parse_url($_SERVER['HTTP_REFERER']);
+            $origin = $url_parts['scheme'].'://'.$url_parts['host'];
+            if ($url_parts['port']) {
+                $origin = $origin.':'.$url_parts['port'];
+            }
+            
+            header("Access-Control-Allow-Origin: ".$origin);
+            header("Access-Control-Allow-Credentials: true");
+            header("Access-Control-Allow-Headers: Content-Type");
+            exit;
+        }
 
         if (!isset($this->paths)) {
             trigger_error($type . ': ' . getenv('SERVER_NAME') . ' ' . $uri);


### PR DESCRIPTION
Adds a generic `OPTIONS` request handler to the framework's routing.

This will allow any request to send an OPTIONS request. Subsequent actions (POST, PUT, etc) may need further security to handle CORS but this is to be handled by the implementation, not the framework itself (although a whitelist of allowed domains would be a useful addition at some point!)